### PR TITLE
Fix server host configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Run the following command to start the Gradio interface:
 python gradio_app.py
 ```
 
+Set the `HOST` and `PORT` environment variables to control where the
+web server listens. By default, the app binds to `0.0.0.0` on port
+`7860`, making it accessible on public platforms like Runpod.
+
 Set the `OPENAI_API_KEY` environment variable to avoid interactive prompts:
 
 ```bash

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -1,3 +1,4 @@
+import os
 import gradio as gr
 from database import DatabaseManager
 from annotation import AnnotationManager
@@ -57,7 +58,9 @@ def build_interface():
 
 def main():
     iface = build_interface()
-    iface.launch()
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", "7860"))
+    iface.launch(server_name=host, server_port=port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update Gradio app to read HOST and PORT from environment variables
- document how to expose the interface for remote access

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_b_683cf2cdc7008323adb5dc3aa1e708bc