### PR TITLE
Load OpenAI model list automatically

### DIFF
--- a/annotation.py
+++ b/annotation.py
@@ -4,6 +4,17 @@ from key_manager import get_openai_api_key
 
 client = OpenAI(api_key=get_openai_api_key())
 
+
+def available_models() -> list[str]:
+    """Return a list of model identifiers available to the API key.
+
+    If the request fails, an empty list is returned.
+    """
+    try:  # pragma: no cover - network call
+        return [m.id for m in client.models.list().data]
+    except Exception:
+        return []
+
 class AnnotationManager:
     @staticmethod
     def generate_annotation(image_path: str, prompt: str, model: str) -> str:

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -2,7 +2,7 @@ import os
 import json
 import gradio as gr
 from database import DatabaseManager
-from annotation import AnnotationManager
+from annotation import AnnotationManager, available_models
 from comfy_client import ComfyUIClient
 from config import DEFAULT_PROMPT, COMFY_DEFAULTS
 
@@ -12,10 +12,7 @@ _annotator = AnnotationManager()
 _generation_settings = COMFY_DEFAULTS.copy()
 _comfy = ComfyUIClient(_generation_settings.get("server", ""))
 
-MODELS = [
-    "chatgpt-4o-latest",
-    "gpt-4-turbo",
-]
+MODELS = available_models() or ["gpt-4-turbo"]
 
 
 def _refresh_list():

--- a/ui.py
+++ b/ui.py
@@ -7,7 +7,7 @@ from PyQt5.QtWidgets import (QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
 from PyQt5.QtGui import QPixmap, QColor, QDragEnterEvent, QDropEvent
 from PyQt5.QtCore import Qt, QThread, pyqtSignal
 from database import DatabaseManager
-from annotation import AnnotationManager
+from annotation import AnnotationManager, available_models
 from config import DEFAULT_PROMPT, COMFY_DEFAULTS
 from comfy_client import ComfyUIClient
 
@@ -263,7 +263,8 @@ class ImageAnnotationApp(QMainWindow):
         model_layout = QHBoxLayout()
         model_layout.addWidget(QLabel("LLM Model:"))
         self.model_combo = QComboBox()
-        self.model_combo.addItems(["chatgpt-4o-latest", "o1-mini", "gpt-4o-mini", "o1-preview", "gpt-4-turbo"])
+        models = available_models() or ["gpt-4-turbo"]
+        self.model_combo.addItems(models)
         self.model_combo.setFixedWidth(200)
         model_layout.addWidget(self.model_combo)
         model_layout.addStretch()


### PR DESCRIPTION
## Summary
- add `available_models()` helper in `annotation` to query the OpenAI API
- populate model selection dropdowns using API results in Gradio and PyQt UIs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_683de403e6788323a1c47de9a3136d5b